### PR TITLE
Feature: addMarker() now supports custom icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ be applied to all of the markers; `eachOptions` is the same except that each
 option value can be a vector, where each element corresponds to a single marker
 (recycling will be used if necessary).
 
+Of special note is `options['icon']`, which takes a list of options and produces an [L.Icon](http://leafletjs.com/reference.html#icon) to override the default marker image:
+
+```r
+map$addMarker(32, -70,
+  options=list(icon=list(
+    iconUrl='my-icon.png',
+    iconRetinaUrl='my-icon@2.png',
+    iconSize=c(38, 95),
+    iconAnchor=c(22, 94),
+    popupAnchor=c(-3, -76),
+    shadowUrl='my-icon-shadow.png',
+    shadowRetinaUrl='my-icon-shadow@2x.png',
+    shadowSize=c(68, 95),
+    shadowAnchor=c(22, 94))
+))
+```
+
 Events: `input$MAPID_marker_click`, `input$MAPID_marker_mouseover`,
 `input$MAPID_marker_mouseout`
 

--- a/inst/www/binding.js
+++ b/inst/www/binding.js
@@ -239,6 +239,9 @@ var dataframe = (function() {
   };
 
   methods.addMarker = function(lat, lng, layerId, options, eachOptions) {
+    if ('icon' in options) {
+      options['icon'] = L.icon(options['icon'])
+    }
     var df = dataframe.create()
       .col('lat', lat)
       .col('lng', lng)

--- a/inst/www/binding.js
+++ b/inst/www/binding.js
@@ -239,9 +239,6 @@ var dataframe = (function() {
   };
 
   methods.addMarker = function(lat, lng, layerId, options, eachOptions) {
-    if ('icon' in options) {
-      options['icon'] = L.icon(options['icon'])
-    }
     var df = dataframe.create()
       .col('lat', lat)
       .col('lng', lng)
@@ -253,6 +250,12 @@ var dataframe = (function() {
       (function() {
         var marker = L.marker([df.get(i, 'lat'), df.get(i, 'lng')], df.get(i));
         var thisId = df.get(i, 'layerId');
+
+		var options = df.get(i, 'options');
+		if ('icon' in options) {
+			marker.setIcon(L.icon(options['icon']))
+		}
+
         this.markers.add(marker, thisId);
         marker.on('click', mouseHandler(this.id, thisId, 'marker_click'), this);
         marker.on('mouseover', mouseHandler(this.id, thisId, 'marker_mouseover'), this);

--- a/inst/www/binding.js
+++ b/inst/www/binding.js
@@ -249,6 +249,7 @@ var dataframe = (function() {
 	  for (var key in options) {
 		optionsArray.push(options[key]);
 	  }
+	  optionsArray.reverse()
 	  
       df.col('options', optionsArray)
       .cbind(eachOptions);

--- a/inst/www/binding.js
+++ b/inst/www/binding.js
@@ -77,8 +77,9 @@ var dataframe = (function() {
       index = this.colnames.length;
       this.colnames.push(name);
     }
-    this.columns[index] = asArray(values);
-    this.colstrict[index] = !!strict;
+    
+	this.columns[index] = asArray(values);
+	this.colstrict[index] = !!strict;
 
     // TODO: Validate strictness (ensure lengths match up with other stricts)
 
@@ -242,15 +243,21 @@ var dataframe = (function() {
     var df = dataframe.create()
       .col('lat', lat)
       .col('lng', lng)
-      .col('layerId', layerId)
-      .cbind(options)
+      .col('layerId', layerId);
+	  
+	  var optionsArray = []
+	  for (var key in options) {
+		optionsArray.push(options[key]);
+	  }
+	  
+      df.col('options', optionsArray)
       .cbind(eachOptions);
 
     for (var i = 0; i < df.nrow(); i++) {
       (function() {
-	  	var options = df.get(i);
+	  	var options = df.get(i, 'options');
 		if ('icon' in options) {
-			options['icon'] = L.icon(options['icon']))
+			options['icon'] = L.icon(options['icon']);
 		}
 		
         var marker = L.marker([df.get(i, 'lat'), df.get(i, 'lng')], options);

--- a/inst/www/binding.js
+++ b/inst/www/binding.js
@@ -248,14 +248,13 @@ var dataframe = (function() {
 
     for (var i = 0; i < df.nrow(); i++) {
       (function() {
-        var marker = L.marker([df.get(i, 'lat'), df.get(i, 'lng')], df.get(i));
-        var thisId = df.get(i, 'layerId');
-
-		var options = df.get(i, 'options');
+	  	var options = df.get(i);
 		if ('icon' in options) {
-			marker.setIcon(L.icon(options['icon']))
+			options['icon'] = L.icon(options['icon']))
 		}
-
+		
+        var marker = L.marker([df.get(i, 'lat'), df.get(i, 'lng')], options);
+        var thisId = df.get(i, 'layerId');
         this.markers.add(marker, thisId);
         marker.on('click', mouseHandler(this.id, thisId, 'marker_click'), this);
         marker.on('mouseover', mouseHandler(this.id, thisId, 'marker_mouseover'), this);


### PR DESCRIPTION
Hi there,

I started using your leaflet wrapper and found that I wanted to override the default marker that is created by the addMarker() call. Leaflet already supports this, so I made a minor change to bindings.js to parse out the "icon" option and turn it into an L.Icon.

I'm not a Javascript programmer, but I took a shot at this and it seems to work fine for me.

Cheers,
Chris
